### PR TITLE
Update Ravelin API to post to a TLS 1.2 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,8 @@ Add missing fields to Pretransaction Object
 # 0.1.4
 
 Ravelin sends the work `null` in responses if there are no changes.  This causes JSON.parse to fail.
+
+
+# 0.1.9
+
+Added support for tags.

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -37,6 +37,7 @@ module Ravelin
     attr_accessor :faraday_adapter, :faraday_timeout
 
     def camelize(str)
+      return '3ds' if str == :three_d_secure # hack to get around Ruby not support 3ds an attribute.
       str.to_s.gsub(/_(.)/) { |e| $1.upcase }
     end
 

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -26,6 +26,7 @@ require 'ravelin/voucher_redemption'
 require 'ravelin/label'
 
 require 'ravelin/event'
+require 'ravelin/tag'
 require 'ravelin/response'
 require 'ravelin/client'
 

--- a/lib/ravelin.rb
+++ b/lib/ravelin.rb
@@ -20,6 +20,7 @@ require 'ravelin/location'
 require 'ravelin/order'
 require 'ravelin/payment_method'
 require 'ravelin/pre_transaction'
+require 'ravelin/three_d_secure'
 require 'ravelin/transaction'
 require 'ravelin/voucher'
 require 'ravelin/voucher_redemption'
@@ -36,9 +37,10 @@ module Ravelin
   class << self
     attr_accessor :faraday_adapter, :faraday_timeout
 
-    def camelize(str)
-      return '3ds' if str == :three_d_secure # hack to get around Ruby not support 3ds an attribute.
-      str.to_s.gsub(/_(.)/) { |e| $1.upcase }
+    def camelize(key)
+      return '3ds' if key == :three_d_secure
+
+      key.to_s.gsub(/_(.)/) { Regexp.last_match(1).upcase }
     end
 
     def datetime_to_epoch(val)

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -39,6 +39,12 @@ module Ravelin
       post("/v2/backfill/#{event.name}", event.serializable_hash)
     end
 
+    def send_tag(**args)
+      tag = Tag.new(**args)
+
+      post("/v2/tag/customer", tag.serializable_hash)
+    end
+
     private
 
     def post(url, payload)

--- a/lib/ravelin/client.rb
+++ b/lib/ravelin/client.rb
@@ -9,7 +9,7 @@ end
 
 module Ravelin
   class Client
-    API_BASE = 'https://api.ravelin.com'
+    API_BASE = 'https://api-tls12.ravelin.com'
 
     def initialize(api_key:)
       @api_key = api_key

--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -59,8 +59,10 @@ module Ravelin
       when :login
         validate_payload_inclusion_of :customer_id
       when :checkout
-        validate_payload_inclusion_of :customer, :order,
-          :payment_method, :transaction
+        validate_payload_must_include_one_of(
+          :payment_method_id, :payment_method
+        )
+        validate_payload_inclusion_of :customer, :order
       end
     end
 

--- a/lib/ravelin/tag.rb
+++ b/lib/ravelin/tag.rb
@@ -1,0 +1,32 @@
+module Ravelin
+  class Tag
+    def initialize(payload:)
+      @payload = convert_to_ravelin_objects(payload)
+    end
+
+    def serializable_hash
+      hash_map(payload) do |k, v|
+        k = Ravelin.camelize(k)
+
+        [k, v]
+      end
+    end
+
+    private
+
+    attr_accessor :payload
+
+    def convert_to_ravelin_objects(payload)
+      hash_map(payload) do |k, v|
+        k = k.to_sym
+        v = Ravelin.convert_ids_to_strings(k, v)
+
+        [k, v]
+      end
+    end
+
+    def hash_map(hash, &block)
+      Hash[hash.map { |k, v| block.call(k, v) }]
+    end
+  end
+end

--- a/lib/ravelin/three_d_secure.rb
+++ b/lib/ravelin/three_d_secure.rb
@@ -1,0 +1,29 @@
+module Ravelin
+  class ThreeDSecure < RavelinObject
+    attr_accessor :attempted,
+                  :success,
+                  :start_time,
+                  :end_time,
+                  :timed_out
+
+    def serializable_hash
+      {
+        'attempted' => boolean(attempted),
+        'success'   => boolean(success),
+        'startTime' => timestamp(start_time),
+        'endTime'   => timestamp(end_time),
+        'timedOut'  => boolean(timed_out)
+      }
+    end
+
+    private
+
+    def boolean(bool)
+      bool || false
+    end
+
+    def timestamp(time)
+      time.to_i
+    end
+  end
+end

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -1,27 +1,38 @@
 module Ravelin
   class Transaction < RavelinObject
     attr_accessor :transaction_id,
-      :email,
-      :currency,
-      :debit,
-      :credit,
-      :gateway,
-      :custom,
-      :success,
-      :auth_code,
-      :decline_code,
-      :gateway_reference,
-      :avs_result_code,
-      :cvv_result_code,
-      :type,
-      :time
+                  :email,
+                  :currency,
+                  :debit,
+                  :credit,
+                  :gateway,
+                  :custom,
+                  :success,
+                  :auth_code,
+                  :decline_code,
+                  :gateway_reference,
+                  :avs_result_code,
+                  :cvv_result_code,
+                  :type,
+                  :time,
+                  :three_d_secure
 
     attr_required :transaction_id,
-      :currency,
-      :debit,
-      :credit,
-      :gateway,
-      :gateway_reference,
-      :success
+                  :currency,
+                  :debit,
+                  :credit,
+                  :gateway,
+                  :gateway_reference,
+                  :success
+
+    def initialize(params)
+      three_d_secure_data = params['3ds']
+      unless three_d_secure_data.nil?
+        self.three_d_secure = three_d_secure_data
+        params.delete('3ds')
+      end
+
+      super(params)
+    end
   end
 end

--- a/lib/ravelin/transaction.rb
+++ b/lib/ravelin/transaction.rb
@@ -26,9 +26,8 @@ module Ravelin
                   :success
 
     def initialize(params)
-      three_d_secure_data = params['3ds']
-      unless three_d_secure_data.nil?
-        self.three_d_secure = three_d_secure_data
+      unless params['3ds'].nil?
+        self.three_d_secure = ThreeDSecure.new(params['3ds'])
         params.delete('3ds')
       end
 

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -4,7 +4,7 @@ describe Ravelin::Client do
   describe '#initialize' do
     it 'initializes a Faraday connection' do
       expect(Faraday).to receive(:new).
-        with('https://api.ravelin.com', kind_of(Hash))
+        with('https://api-tls12.ravelin.com', kind_of(Hash))
 
       described_class.new(api_key: 'abc')
     end
@@ -102,7 +102,7 @@ describe Ravelin::Client do
     end
 
     it 'calls Ravelin with correct headers and body' do
-      stub = stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub = stub_request(:post, 'https://api-tls12.ravelin.com/v2/ping').
         with(
           headers: { 'Authorization' => 'token abc' },
           body: { name: 'value' }.to_json,
@@ -118,7 +118,7 @@ describe Ravelin::Client do
 
     context 'response' do
       before do
-        stub_request(:post, 'https://api.ravelin.com/v2/ping').
+        stub_request(:post, 'https://api-tls12.ravelin.com/v2/ping').
           to_return(
             status: response_status,
             body: body
@@ -171,7 +171,7 @@ describe Ravelin::Client do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub_request(:post, 'https://api-tls12.ravelin.com/v2/ping').
         and_return(status: status_code, body: "null")
     end
 
@@ -197,7 +197,7 @@ describe Ravelin::Client do
 
     before do
       allow(Ravelin::Event).to receive(:new).and_return(event)
-      stub_request(:post, 'https://api.ravelin.com/v2/ping').
+      stub_request(:post, 'https://api-tls12.ravelin.com/v2/ping').
         and_return(status: status_code, body: "{}")
     end
 

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -83,12 +83,13 @@ describe Ravelin::Event do
 
     context '3ds support' do
       let(:event) { described_class.new(name: :transaction, payload: payload) }
+      let(:timestamp) { Time.now.to_i }
       let(:three_d_secure) do
         {
-          attemped: Time.now,
-          success: true,
-          start_time: Time.now.to_i,
-          end_time: Time.now.to_i
+          attempted:  true,
+          success:    true,
+          start_time: timestamp,
+          end_time:   timestamp
         }
       end
       let(:payload) do
@@ -110,7 +111,17 @@ describe Ravelin::Event do
       end
 
       it '3ds is included in the output' do
-        expect(event.serializable_hash['transaction']).to include({ '3ds' => three_d_secure })
+        serialized_transaction = event.serializable_hash['transaction']
+        serialized_three_d_secure = {
+          '3ds' =>  {
+            'attempted' => true,
+            'success'   => true,
+            'startTime' => timestamp,
+            'endTime'   => timestamp,
+            'timedOut'  => false
+          }
+        }
+        expect(serialized_transaction).to include(serialized_three_d_secure)
       end
     end
 

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -81,6 +81,39 @@ describe Ravelin::Event do
       end
     end
 
+    context '3ds support' do
+      let(:event) { described_class.new(name: :transaction, payload: payload) }
+      let(:three_d_secure) do
+        {
+          attemped: Time.now,
+          success: true,
+          start_time: Time.now.to_i,
+          end_time: Time.now.to_i
+        }
+      end
+      let(:payload) do
+        {
+          customer_id: 123,
+          payment_method_id: 123,
+          order_id: 123,
+          transaction: {
+            transaction_id: 123,
+            currency: 'GBP',
+            debit: 100,
+            credit: 0,
+            gateway: 'stripe',
+            gateway_reference: 123,
+            success: true,
+            '3ds' => three_d_secure
+          }
+        }
+      end
+
+      it '3ds is included in the output' do
+        expect(event.serializable_hash['transaction']).to include({ '3ds' => three_d_secure })
+      end
+    end
+
     context 'required mutually exclusive params' do
       let(:payload) do
         {

--- a/spec/ravelin/tag_spec.rb
+++ b/spec/ravelin/tag_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Ravelin::Tag do
+  let(:tag) { described_class.new(payload: {}) }
+
+  describe '#serializable_hash' do
+    let(:payload) { { customer_id: 1234, tag_names: %w(tester staff) } }
+
+    before { allow(tag).to receive(:payload).and_return(payload) }
+
+    it 'returns a hash with the expected contents' do
+      expect(tag.serializable_hash).to eq({
+        "customerId" => 1234,
+        "tagNames" => ["tester", "staff"]
+      })
+    end
+  end
+end

--- a/spec/ravelin/three_d_secure_spec.rb
+++ b/spec/ravelin/three_d_secure_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Ravelin::ThreeDSecure do
+  let(:timestamp) { Time.new(2017).to_i }
+  let(:params) do
+    {
+      attempted:  true,
+      success:    true,
+      start_time: timestamp,
+      end_time:   timestamp
+    }
+  end
+
+  subject do
+    described_class.new(params)
+  end
+
+  describe '#serializable_hash' do
+    it 'is camelized and well formed' do
+      expect(subject.serializable_hash).to eql(
+        'attempted' => true,
+        'success'   => true,
+        'startTime' => timestamp,
+        'endTime'   => timestamp,
+        'timedOut'  => false
+      )
+    end
+
+    context 'when 3DS has timed out' do
+      let(:params) do
+        {
+          attempted:  true,
+          success:    false,
+          start_time: timestamp,
+          end_time:   nil,
+          timed_out:  true
+        }
+      end
+
+      it 'is still camelized and well formed' do
+        expect(subject.serializable_hash).to eql(
+          'attempted' => true,
+          'success'   => false,
+          'startTime' => timestamp,
+          'endTime'   => 0,
+          'timedOut'  => true
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Background**
In preparation for this requirement, Ravelin plans to disable TLS 1.0 and TLS 1.1 as of the 1st November 2017 for the entire ravelin.com domain, this will include:
api.ravelin.com
cdn.ravelin.com
vault.ravelin.com

**Changes**
change https://api.ravelin.com to https://api-tls12.ravelin.com